### PR TITLE
Update to Yew v0.21.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/butzist/yew-plotly.git"
 [dependencies]
 plotly = { version = "0.8.3", features = ["wasm"] }
 wasm-bindgen = "0.2.83"
-yew = "0.20.0"
+yew = "0.21.0"
 
 [[example]]
 name = "scatter"


### PR DESCRIPTION
This fixes trait mismatch issues when building with Yew v0.21.