### PR TITLE
add version to yew dev_dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ yew = "0.21.0"
 name = "scatter"
 
 [dev_dependencies.yew]
+version = "0.21.0"
 features = ["csr"]


### PR DESCRIPTION
This fixes the error:

```
error: failed to parse manifest at `/home/alvie/Documents/projects/yew-plotly/Cargo.toml`

Caused by:
  dependency (yew) specified without providing a local path, Git repository, version, or workspace dependency to use
```

when trying to run `cargo check` or `trunk serve` in a project that uses it. 

I am using cargo version `1.79.0 (ffa9cf99a 2024-06-03)`